### PR TITLE
General upgrades to Python3 with warning fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.os }} ${{ matrix.python-version }}
         if: always()
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,21 @@
 # History
 
+## 0.3.3
+- bump integration test to using Python3 instead Python2
+
+- bump base tox python to 3.10
+
+- bump gitactions checkout and setup-python versions
+
+- fix warning: 'cpp_std', 'tags' warnings.warn(msg)
+
+## 0.3.2
+- github-action: rename cicd_test.yml to tests.yml
+
+## 0.3.1
+- github-action: fix test branch to main
+
+
 ## 0.3.0
 
 - Update README.md.

--- a/cython_setuptools/vendor.py
+++ b/cython_setuptools/vendor.py
@@ -203,6 +203,11 @@ def create_cython_ext_modules(cython_modules, profile_cython=False, debug=False)
                 args = kwargs.setdefault(args_name, [])
                 if "-g" not in args:
                     args.append("-g")
+        # Remove custom cython_setuptools options
+        if "cpp_std" in kwargs:
+            del kwargs["cpp_std"]
+        if "tags" in kwargs:
+            del kwargs["tags"]
         ext = Extension(**kwargs)
         ret.append(ext)
     return ret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
     "flake8",
     "pytest",
     "virtualenv",
+    "cython",
     "pytest-virtualenv",
     "six"]
 

--- a/tests/pypkg/foo.pyx
+++ b/tests/pypkg/foo.pyx
@@ -1,6 +1,8 @@
+# cython: language_level=3
+
 cdef extern from "foo.h":
     int foo()
 
 
 def bar():
-    print foo()
+    print(foo())

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,18 @@ isolated_build = true
 
 [gh-actions]
 python =
-    3.8: py38, 
-    3.9: py39, flake8
-    3.10: py310,
+    3.8: py38,
+    3.9: py39,
+    3.10: py310, flake8
     3.11: py311,
 
 [testenv]
 extras = dev
-commands = 
+commands =
     pip install -e ".[dev]"
-    pytest 
+    pytest
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3.10
 deps = flake8
 commands = flake8 cython_setuptools tests


### PR DESCRIPTION
# This PR

### * Bump integration test to Python3

### * Bump base tox python to 3.10

### * Bump gitactions checkout and setup-python versions

### * Fix Warning 
This will prevent this type of warning:

.sx/stupeflix/lib/python3.10/site-packages/setuptools/_distutils/extension.py:134:
 UserWarning: Unknown Extension options: 'cpp_std', 'tags' warnings.warn(msg)

It's wrong to forward the keyword 'cpp_std' and 'tags' to cython.Extension and the latter is used to fill the extra_compile_args in:

https://github.com/gopro/cython-setuptools/blob/main/cython_setuptools/vendor.py#L295-L296