### PR TITLE
pyproject: bump setuptools to last version and set fixed version for …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools==71.0.1",
-    "wheel",
+    "setuptools==78.1.0",
+    "wheel==0.46.0",
     "setuptools_scm>=6.4", # for automated versioning
     ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
…wheel

The previous version of setuptools was not compatible with the last version of wheel 0.46.0 that released today