### PR TITLE
pyproject.py: forward language to kwargs

### DIFF
--- a/cython_setuptools/pyproject.py
+++ b/cython_setuptools/pyproject.py
@@ -54,6 +54,7 @@ class CythonSetuptoolsOptions:
             "include_dirs": self.include_dirs,
             "extra_compile_args": self.extra_compile_args,
             "extra_link_args": self.extra_link_args,
+            "language": self.language,
         }
 
 


### PR DESCRIPTION
Otherwise it is missing and it will always generate C files instead of C++ files