### PR TITLE
Update wheel version in pyproject.toml to 0.45.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools==78.1.0",
-    "wheel==0.46.0",
+    "wheel==0.45.1",
     "setuptools_scm>=6.4", # for automated versioning
     ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Because 0.46.0 and 0.46.1 were yanked so 0.45.1 is the most up to date good version